### PR TITLE
Add permissions to manage SageMaker tags

### DIFF
--- a/cdk/cdk/bootstrap.py
+++ b/cdk/cdk/bootstrap.py
@@ -163,7 +163,11 @@ class BootstrapStack(core.Stack):
                             "sagemaker:DeleteNotebookInstanceLifecycleConfig",
                             "sagemaker:UpdateNotebookInstanceLifecycleConfig",
                             "sagemaker:CreateNotebookInstance",
-                            "sagemaker:UpdateNotebookInstance"
+                            "sagemaker:UpdateNotebookInstance",
+                            "sagemaker:AddTags",
+                            "sagemaker:DeleteTags",
+                            "sagemaker:ListTags",
+
                         ],
                         resources=[
                             f"arn:aws:sagemaker:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:notebook-instance/{self.afa_stack_name.lower()}*",

--- a/cdk/cdk/stack.py
+++ b/cdk/cdk/stack.py
@@ -154,7 +154,11 @@ class AfaStack(cdk.Stack):
                             "sagemaker:DeleteNotebookInstanceLifecycleConfig",
                             "sagemaker:UpdateNotebookInstanceLifecycleConfig",
                             "sagemaker:CreateNotebookInstance",
-                            "sagemaker:UpdateNotebookInstance"
+                            "sagemaker:UpdateNotebookInstance",
+                            "sagemaker:AddTags",
+                            "sagemaker:DeleteTags",
+                            "sagemaker:ListTags",
+
                         ],
                         resources=[
                             f"arn:aws:sagemaker:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:notebook-instance/{construct_id.lower()}*",

--- a/cfn/cfntemplate.yaml
+++ b/cfn/cfntemplate.yaml
@@ -251,6 +251,9 @@ Resources:
               - sagemaker:UpdateNotebookInstanceLifecycleConfig
               - sagemaker:CreateNotebookInstance
               - sagemaker:UpdateNotebookInstance
+              - sagemaker:AddTags
+              - sagemaker:DeleteTags
+              - sagemaker:ListTags
             Effect: Allow
             Resource:
               - Fn::Join:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add permissions to SageMaker tags, to fix stack-creation error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
