### PR TITLE
feat: upgraded to CDK V2 with fixes to other minor issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ deploy: build/template.yaml .venv
 # Deploy the ui stack
 deploy-ui: cdk/app.py .venv
 	source $(word 2, $^)/bin/activate ; \
-	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws ; \
 	cdk deploy -a 'python3 -B $<' ${AFA_STACK_NAME} \
 		--require-approval never \
 		--parameters ${AFA_STACK_NAME}:emailAddress=${EMAIL} \

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ deploy: build/template.yaml .venv
 # Deploy the ui stack
 deploy-ui: cdk/app.py .venv
 	source $(word 2, $^)/bin/activate ; \
+	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws ; \
 	cdk deploy -a 'python3 -B $<' ${AFA_STACK_NAME} \
 		--require-approval never \
 		--parameters ${AFA_STACK_NAME}:emailAddress=${EMAIL} \

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,7 @@ phases:
       python: 3.9
     commands:
       - pip install -q tox
-      - npm i --silent --quiet --no-progress -g aws-cdk@2.17.0
+      - npm i --silent --quiet --no-progress -g aws-cdk@2.43.1
   pre_build:
     commands:
       - make tox

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -10,7 +10,7 @@ Requirements:
 
 ```bash
 # install `cdk`
-npm i -g aws-cdk@2.13.0 # (or similar version ~2.x.x)
+npm i -g aws-cdk@2.43.1
 
 # deploy AFA
 make deploy EMAIL=<your email address> INSTANCE_TYPE=<ml.* ec2 instance type>

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -2,8 +2,7 @@
 import os
 import sys
 
-from aws_cdk import core
-from aws_cdk import core as cdk
+import aws_cdk as core
 
 from cdk.stack import AfaStack
 from cdk.bootstrap import BootstrapStack

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,17 +1,48 @@
 {
-  "app": "python3 -B app.py",
+  "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
   "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:enableStackNameDuplicates": "true",
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
     "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,    
+    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
+    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,    
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk/cdk/afc_lambdas/create_predictor.py
+++ b/cdk/cdk/afc_lambdas/create_predictor.py
@@ -42,40 +42,27 @@ def create_predictor_handler(event, context):
         payload["StatusJsonS3Path"])
 
     AFC_DATASET_GROUP_ARN = payload["DatasetGroupArn"]
-    AFC_FORECAST_HORIZON = payload["horiz"] + 1
+    AFC_FORECAST_HORIZON = payload["horiz"]
     AFC_FORECAST_FREQUENCY = payload["freq"]
     #AFC_ALGORITHM_NAME = "NPTS"
     #AFC_ALGORITHM_ARN = "arn:aws:forecast:::algorithm/NPTS"
     AFC_PREDICTOR_NAME = f"{prefix}_AutoML"
 
-    create_predictor_resp = afc.create_predictor(
+    create_predictor_resp = afc.create_auto_predictor(
         PredictorName=AFC_PREDICTOR_NAME,
         ForecastHorizon=AFC_FORECAST_HORIZON,
-        #AlgorithmArn=AFC_ALGORITHM_ARN, # TODO: delete this when ready
-        PerformAutoML=True, # TODO: Uncomment this when ready
-        #PerformHPO=False,
-        EvaluationParameters={
-            "NumberOfBacktestWindows": 5
-        },
-        InputDataConfig={
-            "DatasetGroupArn": AFC_DATASET_GROUP_ARN
-        },
-        FeaturizationConfig={
-            "ForecastFrequency": AFC_FORECAST_FREQUENCY,
-            "Featurizations": [
+        ForecastFrequency=AFC_FORECAST_FREQUENCY,
+        DataConfig={
+            "DatasetGroupArn": AFC_DATASET_GROUP_ARN,
+            "AttributeConfigs":[
                 {
                     "AttributeName": "demand",
-                    "FeaturizationPipeline": [
-                        {
-                            "FeaturizationMethodName": "filling",
-                            "FeaturizationMethodParameters": {
-                                "aggregation": "sum",
-                                "frontfill": "none",
-                                "middlefill": "zero",
-                                "backfill": "zero"
-                            }
-                        }
-                    ]
+                    "Transformations": {
+                        "aggregation": "sum",
+                        "frontfill": "none",
+                        "middlefill": "zero",
+                        "backfill": "zero"
+                    }
                 }
             ]
         }

--- a/cdk/cdk/bootstrap.py
+++ b/cdk/cdk/bootstrap.py
@@ -2,9 +2,10 @@
 import os
 
 from textwrap import dedent
+import aws_cdk as core
+from constructs import Construct
 from aws_cdk import (
-    core,
-    core as cdk,
+    Stack,
     aws_lambda as lambda_,
     aws_iam as iam,
     aws_codebuild as codebuild,
@@ -35,8 +36,8 @@ def lambda_handler(event, context):
 """)
 
 
-class BootstrapStack(core.Stack):
-    def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
+class BootstrapStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         """
         """
         super().__init__(scope, construct_id)
@@ -163,7 +164,8 @@ class BootstrapStack(core.Stack):
                             "sagemaker:DeleteNotebookInstanceLifecycleConfig",
                             "sagemaker:UpdateNotebookInstanceLifecycleConfig",
                             "sagemaker:CreateNotebookInstance",
-                            "sagemaker:UpdateNotebookInstance"
+                            "sagemaker:UpdateNotebookInstance",
+                            "sagemaker:AddTags",
                         ],
                         resources=[
                             f"arn:aws:sagemaker:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:notebook-instance/{self.afa_stack_name.lower()}*",
@@ -262,7 +264,7 @@ class BootstrapStack(core.Stack):
                 codebuild_project_id,
                 environment=codebuild.BuildEnvironment(
                     privileged=True,
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_3
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4
                 ),
                 environment_variables={
                     "LAMBDAMAP_STACK_NAME": codebuild.BuildEnvironmentVariable(value=LAMBDAMAP_STACK_NAME),

--- a/cdk/cdk/bootstrap.py
+++ b/cdk/cdk/bootstrap.py
@@ -250,7 +250,10 @@ class BootstrapStack(Stack):
                             "ecr:PutImageScanningConfiguration",
                             "ecr:DeleteRepository",
                             "ecr:TagResource",
-                            "ecr:UntagResource"
+                            "ecr:UntagResource",
+                            "ecr-public:GetAuthorizationToken",
+                            "sts:GetServiceBearerToken",
+                            "ecr:PutImageTagMutability"
                         ],
                         resources=[
                             f"*"
@@ -287,7 +290,8 @@ class BootstrapStack(Stack):
                                     f"""export CDK_TAGS=$(aws cloudformation describe-stacks --stack-name {core.Aws.STACK_NAME} --query Stacks[0].Tags | python -c 'import sys, json; print(" ".join("--tags " + d["Key"] + "=" + d["Value"] for d in json.load(sys.stdin)))')""",
                                     "export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)",
                                     "export BOOTSTRAP_URL=aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION",
-                                    "npm i --silent --quiet --no-progress -g aws-cdk@2.17.0",
+                                    "npm i --silent --quiet --no-progress -g aws-cdk@2.43.1",
+                                    "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
                                     "(( [[ -n \"CDK_TAGS\" ]] ) && ( cdk bootstrap ${BOOTSTRAP_URL} )) || ( cdk bootstrap ${BOOTSTRAP_URL} )"
                                 ]
                             },

--- a/cdk/cdk/stack.py
+++ b/cdk/cdk/stack.py
@@ -1,6 +1,8 @@
 import os
 
 from textwrap import dedent
+from constructs import Construct
+import aws_cdk as core
 from aws_cdk import (
     aws_s3 as s3,
     aws_ssm as ssm,
@@ -12,8 +14,7 @@ from aws_cdk import (
     aws_ec2 as ec2,
     aws_stepfunctions as sfn,
     aws_stepfunctions_tasks as tasks,
-    core,
-    core as cdk,
+    Stack,
     aws_codebuild as codebuild
 )
 
@@ -23,8 +24,8 @@ TAG_NAME = "Project"
 TAG_VALUE = "Afa"
 
 
-class AfaStack(cdk.Stack):
-    def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
+class AfaStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(
             scope,
             construct_id,

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,9 +1,3 @@
-aws-cdk.core==1.116.0
-aws-cdk.aws-iam==1.116.0
-aws-cdk.aws-sagemaker==1.116.0
-aws-cdk.aws-stepfunctions==1.116.0 
-aws-cdk.aws-stepfunctions-tasks==1.116.0 
-aws-cdk.aws-sns==1.116.0
-aws-cdk.aws-sns-subscriptions==1.116.0
-aws-cdk.aws-s3==1.116.0
+aws-cdk-lib==2.43.1
+constructs>=10.0.0,<11.0.0
 aws-sam-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,13 @@
-aws-cdk.core==1.116.0
-aws-cdk.aws-iam==1.116.0
-aws-cdk.aws-sagemaker==1.116.0
-aws-cdk.aws-stepfunctions==1.116.0 
-aws-cdk.aws-stepfunctions-tasks==1.116.0 
-aws-cdk.aws-sns==1.116.0
-aws-cdk.aws-sns-subscriptions==1.116.0
-aws-cdk.aws-s3==1.116.0
+# aws-cdk.core==1.116.0
+# aws-cdk.aws-iam==1.116.0
+# aws-cdk.aws-sagemaker==1.116.0
+# aws-cdk.aws-stepfunctions==1.116.0 
+# aws-cdk.aws-stepfunctions-tasks==1.116.0 
+# aws-cdk.aws-sns==1.116.0
+# aws-cdk.aws-sns-subscriptions==1.116.0
+# aws-cdk.aws-s3==1.116.0
+aws-cdk-lib==2.43.1
+constructs>=10.0.0,<11.0.0
 aws-sam-cli
 ipython
 pytest


### PR DESCRIPTION
- For stacks, modified CDK version to V2, this is for using `codebuild.LinuxBuildImage.AMAZON_LINUX_2_4` with support for **NodeJS 16**. Without this, the CodeBuild project fails without creating CFN stacks of `AfaLambdaMapStack` and `AfaStack`
- Added `aws ecr-public login` required by CodeBuild job, and permissions required by the assumed IAM Role
- Added missing permission "sagemaker:AddTags" that without it could result a failure in creating CFN stack
- Fixed Lambda function by changing to use `create_auto_predictor`. The previous code could result error of `Please ensure that for each BackTest Window, we have data of at least content_length to train on` thrown to Step Function execution


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
